### PR TITLE
adding pg dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.24.1",
   "homepage": "https://github.com/chilts/koa-pg",
   "dependencies": {
-    "co-pg": "^1.3.1"
+    "co-pg": "^1.3.1",
+    "pg": "^4.4.1"
   },
   "devDependencies": {
     "koa": "^0.17.0"


### PR DESCRIPTION
`index.js` calls `require('pg')` on line 12, but `pg` is not currently listed as a dependency in `package.json`. Adding.
