### PR TITLE
If conStr is not defined, pass opts as a config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ app.use(function *(next) {
 app.listen(3000)
 ```
 
+With a `node-postgres` config object, client pooling enabled:
+
+```js
+var koa = require('koa')
+var koaPg = require('koa-pg')
+
+var app = koa()
+
+var config = {
+    name: 'master_db',
+    pg: {
+        user: 'postgres',
+	database: 'db',
+	password: 'pass',
+	port: 5432,
+	max: 10,
+	idleTimeoutMillis: 60
+    }
+}	
+
+app.use(koaPg(config))
+
+app.use(function *(next) {
+    // ...
+})
+
+app.listen(3000)
+```
+
 ## Options ##
 
 * 'name' : default -> 'db'
@@ -41,7 +70,7 @@ the default. See below if you require two or more database connections (such as 
 ```
 app.use(koaPg({
     name   : 'master',
-    conStr : 'postgres://user:password@localhost:5432/database'
+    pg : 'postgres://user:password@localhost:5432/database'
 }))
 
 app.use(function *(next) {
@@ -49,6 +78,11 @@ app.use(function *(next) {
     this.body = result.rows[0].now.toISOString()
 })
 ```
+
+* 'pg'
+
+This is the parameter that is passed via `co-pg` to `node-postgres`. It can be
+either a string or an object.
 
 ## Multiple Database Connections ##
 
@@ -60,12 +94,12 @@ depending on what operations you are doing).
 ```
 app.use(koaPg({
     name   : 'master',
-    conStr : 'postgres://user:password@masterhost:5432/database'
+    pg : 'postgres://user:password@masterhost:5432/database'
 }))
 
 app.use(koaPg({
     name   : 'slave',
-    conStr : 'postgres://user:password@slavehost:5432/database'
+    pg : 'postgres://user:password@slavehost:5432/database'
 }))
 
 // a write query

--- a/README.md
+++ b/README.md
@@ -30,35 +30,6 @@ app.use(function *(next) {
 app.listen(3000)
 ```
 
-With a `node-postgres` config object, client pooling enabled:
-
-```js
-var koa = require('koa')
-var koaPg = require('koa-pg')
-
-var app = koa()
-
-var config = {
-    name: 'master_db',
-    pg: {
-        user: 'postgres',
-	database: 'db',
-	password: 'pass',
-	port: 5432,
-	max: 10,
-	idleTimeoutMillis: 60
-    }
-}	
-
-app.use(koaPg(config))
-
-app.use(function *(next) {
-    // ...
-})
-
-app.listen(3000)
-```
-
 ## Options ##
 
 * 'name' : default -> 'db'
@@ -82,7 +53,23 @@ app.use(function *(next) {
 * 'pg'
 
 This is the parameter that is passed via `co-pg` to `node-postgres`. It can be
-either a string or an object.
+either a string or an object and conforms to the API as provided by the aforementioned modules.
+
+```js
+var config = {
+    name: 'master_db',
+    pg: {
+        user: 'postgres',
+        database: 'db',
+        password: 'pass',
+        port: 5432,
+        max: 10,
+        idleTimeoutMillis: 60
+    }
+}
+
+app.use(koaPg(config))
+```
 
 ## Multiple Database Connections ##
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(opts) {
             return {text: result, values: vals};
         };
 
-        var connectionResults = yield pg.connectPromise(opts.conStr);
+        var connectionResults = yield pg.connectPromise(opts.conStr || opts);
 
         this.pg[opts.name] = {
             client: connectionResults[0],

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(opts) {
     "use strict"
 
     if (typeof opts === 'string') {
-        opts = {conStr: opts};
+        opts = {pg: opts};
     }
 
     // set this db name
@@ -41,7 +41,7 @@ module.exports = function(opts) {
             return {text: result, values: vals};
         };
 
-        var connectionResults = yield pg.connectPromise(opts.conStr || opts);
+        var connectionResults = yield pg.connectPromise(opts.pg);
 
         this.pg[opts.name] = {
             client: connectionResults[0],

--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ module.exports = function(opts) {
     if (typeof opts === 'string') {
         opts = {pg: opts};
     }
+    // For legacy support when 'pg' was named 'conStr'.
+    else if (typeof opts.conStr !== 'undefined' &&
+          typeof opts.pg === 'undefined')
+    {
+        //opts.pg = opts.conStr;
+    }
 
     // set this db name
     opts.name = opts.name || 'db';


### PR DESCRIPTION
Heya,

I noticed that koa-pg doesn't allow config objects as used by node-postgres to be passed along. I added a simple check for passing 'opts' object to co-pg instead of opts.conStr if the latter is not defined. This seems to fix the issue, allowing full config objects to be passed along to co-pg instead of just connection strings.
